### PR TITLE
fix: wrong key name reference in template definition

### DIFF
--- a/internal/bootstrap/files.go
+++ b/internal/bootstrap/files.go
@@ -62,7 +62,7 @@ spec:
   {{- end -}}
 {{- end }}
 `
-const serviceMonitorTemplate = `{{- if and .Values.%[1]s.enabled .Values.%[1]s.serviceMonitor.enabled }}
+const serviceMonitorTemplate = `{{- if and .Values.%[2]s.enabled .Values.%[2]s.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
# Description

This PR fixes a problem related to an incorrect "value" key name. In previous versions, the template check in the first line checked if `.Values.<chart-name>.serviceMonitor.enabled` was set. `.Values.<chart-name>` is not a property in the values.yaml, which caused a problem during chart execution.

## How Has This Been Tested?

- [x] helm create example && go run cmd/bootstrap/main.go ./example

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
