### PR TITLE
fix: service monitor port reference

### DIFF
--- a/internal/bootstrap/files.go
+++ b/internal/bootstrap/files.go
@@ -74,7 +74,7 @@ metadata:
     {{- include "%[1]s.labels" . | nindent 4 }}
 spec:
   endpoints:
-    - port: {{ .Values.service.port }}
+    - port: http
       path: {{ .Values.%[2]s.serviceMonitor.metricsPath }}
       {{- with .Values.%[2]s.serviceMonitor.interval }}
       interval: {{ . }}


### PR DESCRIPTION
# Description

Fix wrong port type reference in Service Monitor endpoints configuration.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
